### PR TITLE
Relax some lower bounds.

### DIFF
--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -18,8 +18,8 @@ library
   default-language:     Haskell2010
   default-extensions:   OverloadedStrings
   ghc-options:          -Wall
-  build-depends:        aeson                >= 0.8  && < 0.9
-                      , base                 >= 4.7  && < 4.9
+  build-depends:        aeson                >= 0.7  && < 0.9
+                      , base                 >= 4.6  && < 4.9
                       , unordered-containers >= 0.2  && < 0.3
                       , text                 >= 1.2  && < 1.3
                       , vector               >= 0.10 && < 0.11


### PR DESCRIPTION
This allows compatibility with ghc-7.6, which is still, for instance, the default compiler in the just-released Debian Jessie.
