### PR TITLE
Add GHC-8.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ matrix:
     - compiler: "ghc-7.10.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.0.1"
+    - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -10,7 +10,7 @@ category:           Data
 build-type:         Simple
 cabal-version:      >=1.10
 -- Rerun multi-ghc-travis (executable make-travis-yml-2) after changing:
-Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2
+Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1
 extra-source-files:
   changelog.md
   README.md

--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -10,7 +10,7 @@ category:           Data
 build-type:         Simple
 cabal-version:      >=1.10
 -- Rerun multi-ghc-travis (executable make-travis-yml-2) after changing:
-Tested-With:        GHC == 7.10.3, GHC == 8.0.1, GHC == 8.2.1
+Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2
 extra-source-files:
   changelog.md
   README.md

--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -24,7 +24,7 @@ library
   exposed-modules:
     JSONPointer
   build-depends:
-      base                 >= 4.6 && < 4.11
+      base                 >= 4.6 && < 4.12
     , aeson                >= 0.7
     , hashable             >= 1.2
     , QuickCheck           >= 2.8


### PR DESCRIPTION
- Update Cabal file to support GHC 8.4
- Update GHC minor versions on Travis to 8.0.2 and 8.2.2
- Add GHC 8.4.1 build