### PR TITLE
Removed dependency on QuickCheck

### DIFF
--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -27,7 +27,6 @@ library
       base                 >= 4.6 && < 5
     , aeson                >= 0.7
     , hashable             >= 1.2
-    , QuickCheck           >= 2.8
     , unordered-containers >= 0.2
     , text                 >= 1.2
     , vector               >= 0.10

--- a/src/JSONPointer.hs
+++ b/src/JSONPointer.hs
@@ -13,7 +13,6 @@ import           Data.Text           (Text)
 import qualified Data.Text           as T
 import qualified Data.Vector         as V
 import           GHC.Generics        (Generic)
-import           Test.QuickCheck
 import           Text.Read           (readMaybe)
 
 --------------------------------------------------
@@ -37,7 +36,7 @@ resolve (Pointer (t:ts)) v = resolveToken t v >>= resolve (Pointer ts)
 
 newtype Pointer
     = Pointer { _unPointer :: [Token] }
-    deriving (Eq, Show, Semigroup, Monoid, Generic, Arbitrary)
+    deriving (Eq, Show, Semigroup, Monoid, Generic)
 
 instance HA.Hashable Pointer
 
@@ -62,9 +61,6 @@ newtype Token
     deriving (Eq, Show, Generic)
 
 instance HA.Hashable Token
-
-instance Arbitrary Token where
-    arbitrary = Token . T.pack <$> arbitrary
 
 -- | This escapes @"/"@ (because it's the token separator character).
 --

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main where
 
@@ -13,9 +17,14 @@ import qualified JSONPointer            as JP
 import           Network.HTTP.Types.URI (urlDecode)
 
 import           Test.Hspec
-import           Test.QuickCheck        (property)
+import           Test.QuickCheck        (Arbitrary(..), property)
 
 import qualified Example
+
+deriving instance Arbitrary JP.Pointer
+
+instance Arbitrary JP.Token where
+    arbitrary = JP.Token . T.pack <$> arbitrary
 
 main :: IO ()
 main = hspec $ do


### PR DESCRIPTION
Depending on test frameworks should probably be done in the testsuite.
What was the reason of instantiating Arbitrary in the library in the first place?