### PR TITLE
Tighten bounds of base

### DIFF
--- a/hjsonpointer.cabal
+++ b/hjsonpointer.cabal
@@ -24,7 +24,7 @@ library
   exposed-modules:
     JSONPointer
   build-depends:
-      base                 >= 4.6 && < 5
+      base                 >= 4.9 && < 5
     , aeson                >= 0.7
     , hashable             >= 1.2
     , unordered-containers >= 0.2


### PR DESCRIPTION
As can be seen in a screenshot of the original report from https://matrix.hackage.haskell.org/package/hjsonpointer there were build failures due to inaccurate version bounds:

![hjsonpointer](https://user-images.githubusercontent.com/285533/46263236-e6f69800-c50c-11e8-97bc-68421bee5335.png)

I've already fixed up the affected releases via revisions at

 - https://hackage.haskell.org/package/hjsonpointer-1.3.0/revisions/
 - https://hackage.haskell.org/package/hjsonpointer-1.4.0/revisions/
 - https://hackage.haskell.org/package/hjsonpointer-1.5.0/revisions/
